### PR TITLE
Add AI workshop button and speaker blurb mention

### DIFF
--- a/_includes/buytickets.html
+++ b/_includes/buytickets.html
@@ -1,9 +1,21 @@
-<a
-  href="https://ti.to/goodscary/brightonruby-2026"
-  class="block w-full font-bold text-white bg-red-800 hover:bg-red-600 focus:outline-none focus:border-red-600 focus:shadow-outline-red active:bg-red-600 transition ease-in-out duration-150"
->
-  <div class="py-3 px-2 sm:p-4 text-center">
-    Buy Tickets
-    <span class="hidden sm:inline">for 2026</span>
-  </div>
-</a>
+<div class="md:grid md:grid-cols-2 md:gap-1">
+  <a
+    href="https://ti.to/goodscary/brightonruby-2026"
+    class="block w-full font-bold text-white bg-red-800 hover:bg-red-600 focus:outline-none focus:border-red-600 focus:shadow-outline-red active:bg-red-600 transition ease-in-out duration-150"
+  >
+    <div class="py-3 px-2 sm:p-4 text-center">
+      Buy Tickets
+      <span class="hidden sm:inline">for 2026</span>
+    </div>
+  </a>
+  <a
+    href="https://ti.to/goodscary/brighton-ruby-2026-brian-casel-workshop"
+    class="block w-full font-bold text-white bg-amber-700 hover:bg-amber-600 focus:outline-none focus:border-amber-600 focus:shadow-outline-amber active:bg-amber-600 transition ease-in-out duration-150"
+  >
+    <div class="py-3 px-2 sm:p-4 text-center">
+      AI Workshop
+      <span class="hidden md:inline">with Brian Casel</span>
+      <span class="hidden sm:inline">&mdash; 24th June</span>
+    </div>
+  </a>
+</div>

--- a/_includes/twentytwentysix.html
+++ b/_includes/twentytwentysix.html
@@ -89,7 +89,7 @@
   <div class="container mt-2 px-2 sm:px-4 mx-auto">
     <div class="typography md:columns-2 mb-4">
       <p class="block h-auto max-w-full">
-        <a href="https://buildermethods.com">Brian</a> is the founder of Builder Methods and brings longtime Ruby, Rails, and SaaS experience, having built and sold multiple software products over the past decade. He'll explore what actually changes when experienced developers start building with AI — and what doesn't.
+        <a href="https://buildermethods.com">Brian</a> is the founder of Builder Methods and brings longtime Ruby, Rails, and SaaS experience, having built and sold multiple software products over the past decade. He'll explore what actually changes when experienced developers start building with AI — and what doesn't. Brian is also running a practical, hype-free <a href="https://ti.to/goodscary/brighton-ruby-2026-brian-casel-workshop">AI workshop on the 24th June</a>, the day before the conference, for just 20 attendees.
       </p>
       <p class="block h-auto max-w-full">
         <a href="https://github.com/elenatanasoiu">Elena</a> & <a href="https://github.com/emmagabriel">Emma</a> from GitHub's Performance Engineering team will teach you how to read flamegraphs — the visualization that shows exactly where your code spends time. They'll demonstrate through a real production story where profiling a single page cut CPU consumption by 13%.

--- a/index.html
+++ b/index.html
@@ -25,11 +25,11 @@ image: 'images/twitter-image.jpg'
 
 {% include twentytwentysix.html %}
 
-{% include trailer.html %}
-
 {% include gold.html %}
 
 {% include supporters.html %}
+
+{% include trailer.html %}
 
 {% include headshots.html %}
 


### PR DESCRIPTION
## Summary
- Adds a secondary amber "AI Workshop" button alongside the existing "Buy Tickets" button, linking to Brian Casel's workshop on tito. Buttons sit side-by-side on md+ screens, stacked on mobile.
- Updates Brian's speaker blurb to mention the practical, hype-free workshop on 24th June for 20 attendees.

## Test plan
- [ ] Verify buttons display side-by-side on desktop and stacked on mobile
- [ ] Confirm "with Brian Casel" is hidden on small screens
- [ ] Check workshop link resolves correctly
- [ ] Verify Brian's blurb reads naturally with the workshop mention

🤖 Generated with [Claude Code](https://claude.com/claude-code)