### PR TITLE
Update Maria Yudina's link to LinkedIn

### DIFF
--- a/_includes/twentytwentysix.html
+++ b/_includes/twentytwentysix.html
@@ -49,7 +49,7 @@
         alt="Rémy Hannequin"
       >
     </a>
-    <a href="https://github.com/mariayudina">
+    <a href="https://www.linkedin.com/in/myudina/">
       <img
         src="/images/2026/speakers/maria_yudina.jpg"
         class="w-full aspect-square object-cover rounded-sm"
@@ -107,7 +107,7 @@
         <a href="https://github.com/rhannequin">Rémy</a> is a senior developer at thoughtbot and creator of Astronoby, an astronomy Ruby gem. He'll explore why time is genuinely weird and work through practical patterns for handling it safely in Ruby and Rails.
       </p>
       <p class="block h-auto max-w-full">
-        <a href="https://github.com/mariayudina">Maria</a> is a software developer at Shopify who'll draw on her love of movies and storytelling to show what screenwriting can teach us about writing code and prompts.
+        <a href="https://www.linkedin.com/in/myudina/">Maria</a> is a software developer at Shopify who'll draw on her love of movies and storytelling to show what screenwriting can teach us about writing code and prompts.
       </p>
       <p class="block h-auto max-w-full">
         We'll also have lightning talks from <a href="https://tekin.co.uk">Tekin</a> on internationalisation, <a href="https://github.com/tijmenb">Tijmen</a> on what woodworking can teach us about software, and <a href="https://www.linkedin.com/in/jennie1evans/">Jennie</a> on kindness in development teams.


### PR DESCRIPTION
## Summary
- Updates Maria Yudina's profile link from GitHub to her LinkedIn (`https://www.linkedin.com/in/myudina/`) in both the speaker image link and bio text on the 2026 page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)