### PR TITLE
Update Elena Tanasoiu's link to personal website

### DIFF
--- a/_includes/twentytwentysix.html
+++ b/_includes/twentytwentysix.html
@@ -7,7 +7,7 @@
         alt="Brian Casel"
       >
     </a>
-    <a href="https://github.com/elenatanasoiu">
+    <a href="https://elenatanasoiu.com/">
       <img
         src="/images/2026/speakers/elena_tanasoiu.jpg"
         class="w-full aspect-square object-cover rounded-sm"
@@ -92,7 +92,7 @@
         <a href="https://buildermethods.com">Brian</a> is the founder of Builder Methods and brings longtime Ruby, Rails, and SaaS experience, having built and sold multiple software products over the past decade. He'll explore what actually changes when experienced developers start building with AI — and what doesn't. Brian is also running a practical, hype-free <a href="https://ti.to/goodscary/brighton-ruby-2026-brian-casel-workshop">AI workshop on the 24th June</a>, the day before the conference, for just 20 attendees.
       </p>
       <p class="block h-auto max-w-full">
-        <a href="https://github.com/elenatanasoiu">Elena</a> & <a href="https://github.com/emmagabriel">Emma</a> from GitHub's Performance Engineering team will teach you how to read flamegraphs — the visualization that shows exactly where your code spends time. They'll demonstrate through a real production story where profiling a single page cut CPU consumption by 13%.
+        <a href="https://elenatanasoiu.com/">Elena</a> & <a href="https://github.com/emmagabriel">Emma</a> from GitHub's Performance Engineering team will teach you how to read flamegraphs — the visualization that shows exactly where your code spends time. They'll demonstrate through a real production story where profiling a single page cut CPU consumption by 13%.
       </p>
       <p class="block h-auto max-w-full">
         <a href="https://github.com/CraigDoesCode">Craig</a> is a DevOps Engineer at PassEntry. A former professional musician who transitioned into tech via Le Wagon, he'll share different strategies for managing multi-tenancy in Sidekiq, especially balancing cost and compute with shuffle sharding.

--- a/_posts/2026/2026-06-25-performance-engineering-for-everyone-elena-tanasoiu.md
+++ b/_posts/2026/2026-06-25-performance-engineering-for-everyone-elena-tanasoiu.md
@@ -4,8 +4,8 @@ date: "2026-06-25 10:00"
 author: Elena Tanasoiu & Emma Gabriel
 author_bio_markdown: "Elena Tanasoiu is a Staff Engineer on GitHub's Performance Engineering team. She spends her time making one of the world's largest Ruby on Rails applications faster by profiling production traffic, diagnosing bottlenecks, and occasionally convincing teams they don't need more hardware. She has a fondness for flamegraphs because they never lie. Also enjoys pickles. Emma Gabriel is the Senior Director of Product Management leading GitHub's frontend platform teams. She spends her time figuring out what people actually mean when they say 'this feels slow', and then deciding what to do about it. In a past life, she spent three years as a Ruby on Rails developer; now she has two kids to worry about endlessly, and very little time for anything else."
 author_social:
-  - name: "GitHub (Elena)"
-    url: "https://github.com/elenatanasoiu"
+  - name: "Website (Elena)"
+    url: "https://elenatanasoiu.com/"
   - name: "GitHub (Emma)"
     url: "https://github.com/emmagabriel"
 layout: video


### PR DESCRIPTION
Update Elena Tanasoiu's URL from her GitHub profile to her personal website (https://elenatanasoiu.com/) across the homepage speaker grid, description text, and session post.