### PR TITLE
Fluid typography + sponsor logo wall rework

### DIFF
--- a/_includes/gold.html
+++ b/_includes/gold.html
@@ -1,24 +1,26 @@
 {% if page.gold.size > 0 %}
   <div id="sponsors" class="bg-slate-900 text-amber-50">
     <div class="container mx-auto px-4 pt-4 pb-2">
-      <p class="text-xs opacity-40 text-center md:text-left">Sponsored by...</p>
-      <div class="grid grid-cols-2 md:flex md:items-center gap-4 pt-2">
+      <p class="text-xs opacity-40 text-center">Sponsored by...</p>
+      <div class="flex flex-wrap items-center justify-center gap-x-8 sm:gap-x-12 gap-y-6 pt-2">
         {% for sponsor in page.gold %}
           {% if sponsor.url != null %}
             <a
-              class="w-full md:w-48 px-2"
+              class="block"
               href="{{ sponsor.url }}"
               title="{{ sponsor.name }}"
               target="_blank"
             >
               <img
+                class="h-12 sm:h-16 md:h-18 w-auto"
                 src="/images/2026/sponsors/{{ sponsor.name | downcase | replace: ' ', '_'}}.svg"
                 alt="{{ sponsor.name }} Logo"
               >
             </a>
           {% else %}
-            <div class="w-full md:w-48 px-2">
+            <div class="block">
               <img
+                class="h-12 sm:h-16 md:h-18 w-auto"
                 src="/images/2026/sponsors/{{ sponsor.name | downcase | replace: ' ', '_'}}.svg"
                 alt="{{ sponsor.name }} Logo"
               >

--- a/_includes/supporters.html
+++ b/_includes/supporters.html
@@ -1,24 +1,26 @@
 {% if page.supporters.size > 0 %}
   <div id="supporters" class="bg-slate-900 text-amber-50">
     <div class="container mx-auto px-4 pb-4">
-      <p class="text-xs opacity-40 text-center md:text-left">Supporters</p>
-      <div class="grid grid-cols-3 md:flex md:items-center gap-4 pt-2">
+      <p class="text-xs opacity-40 text-center">Supporters</p>
+      <div class="flex flex-wrap items-center justify-center gap-x-6 sm:gap-x-8 gap-y-4 pt-2 max-w-5xl mx-auto">
         {% for sponsor in page.supporters %}
           {% if sponsor.url != null %}
             <a
-              class="w-full md:w-36 px-2"
+              class="block"
               href="{{ sponsor.url }}"
               title="{{ sponsor.name }}"
               target="_blank"
             >
               <img
+                class="h-7 sm:h-8 md:h-9 w-auto"
                 src="/images/2026/sponsors/{{ sponsor.name | downcase | replace: ' ', '_'}}.svg"
                 alt="{{ sponsor.name }} Logo"
               >
             </a>
           {% else %}
-            <div class="w-full md:w-36 px-2">
+            <div class="block">
               <img
+                class="h-7 sm:h-8 md:h-9 w-auto"
                 src="/images/2026/sponsors/{{ sponsor.name | downcase | replace: ' ', '_'}}.svg"
                 alt="{{ sponsor.name }} Logo"
               >

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -3,6 +3,10 @@
 
 @import "tailwindcss";
 
+html {
+  font-size: clamp(1em, 0.9em + 0.4vi, 1.125em);
+}
+
 @theme {
   --font-mono: "MonoLisa Variable", "ui-monospace", "SFMono-Regular", "Menlo", "Monaco", "Consolas", "Liberation Mono", "Courier New", "monospace";
 }


### PR DESCRIPTION
## Summary

- Adopt Oddbird's conservative fluid-type approach (https://www.oddbird.net/2025/02/12/fluid-type/): one `clamp(1em, 0.9em + 0.4vi, 1.125em)` on `:root` so every rem-based Tailwind utility scales gently with viewport while still respecting browser font-size and zoom preferences. No per-step type scale, no template churn.
- Rework gold + supporter logo walls as height-bound `flex flex-wrap items-center justify-center` rows. Capping height (not width) gives every logo a unified vertical rhythm regardless of its intrinsic aspect ratio.
  - Gold: `h-12 sm:h-16 md:h-18` (48/64/72 px) — centered, prominent.
  - Supporters: `h-7 sm:h-8 md:h-9` (28/32/36 px), grid capped at `max-w-5xl` so the wall doesn't stretch into 7-3 / 9-2 wraps on lg+.
- Centre both section titles ("Sponsored by..." and "Supporters") at all widths.

## Test plan

- [ ] Resize browser from 360px → 2560px and confirm body copy scales gently without ever falling below the user's default font-size.
- [ ] Verify gold logos remain visibly larger than supporter logos at every Tailwind breakpoint (sm/md/lg/xl/2xl).
- [ ] Confirm supporter wall wraps cleanly: 3-3-3-1 (mobile), 4-4-2 (sm/md), 5-5 (lg), 6-4 (xl/2xl).
- [ ] Cleo and AppSignal render at matching heights in the gold row.
- [ ] Browser zoom 50% / 200% — typography still scales with the user's setting.
- [ ] `bundle exec jekyll build && bundle exec htmlproofer ./_site` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)