### PR TITLE
Drop Brian Casel workshop links; add 2026 schedule page

### DIFF
--- a/2026/schedule.html
+++ b/2026/schedule.html
@@ -1,0 +1,96 @@
+---
+layout: default
+title: "Brighton Ruby 2026 — Schedule"
+permalink: /2026/schedule/
+description: "The full schedule for Brighton Ruby 2026, Thursday 25th June at Brighton Dome."
+image: "images/twitter-image.jpg"
+---
+
+<div class="container mx-auto p-2 sm:p-4">
+  <h1 class="font-bold text-2xl">
+    Schedule
+    <span class="text-base font-light italic">Thursday, 25th June 2026</span>
+  </h1>
+</div>
+
+<div class="container mx-auto md:w-3/4 lg:w-1/2 px-2 sm:px-4 pb-6">
+  {% assign ordered_posts = site.posts | sort: 'date' %}
+  {% assign wastalk = false %}
+
+  {% for post in ordered_posts %}
+    {% assign post_year = post.date | date: '%Y' %}
+    {% if post_year != '2026' %}{% continue %}{% endif %}
+
+    {% assign is_break = false %}
+    {% if post.title == 'Registration'
+      or post.title == 'Coffee'
+      or post.title == 'Lunch'
+      or post.title == 'Ice Cream'
+      or post.title == 'Drinks'
+    %}
+      {% assign is_break = true %}
+    {% endif %}
+
+    {% if is_break %}
+      {% capture row_classes %}my-5 opacity-50{% endcapture %}
+    {% else %}
+      {% capture row_classes %}{% endcapture %}
+    {% endif %}
+
+    <div class="{{ row_classes }}">
+      <div class="sm:flex sm:gap-4 my-1">
+        {% if wastalk == false or is_break %}
+          <div class="w-12 flex-none mt-4 sm:mt-0">
+            {{ post.date | date: '%H:%M' }}
+          </div>
+        {% else %}
+          <div class="hidden sm:block w-12 flex-none mt-4 sm:mt-0">&nbsp;</div>
+        {% endif %}
+
+        {% if post.author and is_break == false %}
+          <div class="hidden sm:block w-12 flex-none">
+            {% if post.author_image %}
+              {% assign image_src = post.author_image %}
+            {% else %}
+              {% assign author_slug = post.author | downcase | replace: ' ', '_' %}
+              {% assign image_src = '/images/2026/speakers/' | append: author_slug | append: '.jpg' %}
+            {% endif %}
+            <a href="{{ post.url }}">
+              <img
+                src="{{ image_src | downcase | replace: ' ', '_' }}?width=96&height=96"
+                class="rounded-sm"
+                alt="{{ post.author }}"
+              >
+            </a>
+          </div>
+        {% endif %}
+
+        <div class="flex-1">
+          <h2>
+            {% if is_break %}
+              {{ post.title }}
+            {% else %}
+              <a href="{{ post.url }}">{{ post.title }}</a>
+            {% endif %}
+          </h2>
+          {% if post.author %}
+            <h3 class="italic text-xs leading-6 opacity-60">{{ post.author }}</h3>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+
+    {% if is_break %}
+      {% assign wastalk = false %}
+    {% else %}
+      {% assign wastalk = true %}
+    {% endif %}
+  {% endfor %}
+</div>
+
+<div class="container mx-auto md:w-3/4 lg:w-1/2 px-2 sm:px-4 pb-6">
+  <p class="text-xs leading-6 opacity-40 font-extralight">
+    Programmed &amp; hosted by
+    <a href="https://andycroll.com">Andy Croll</a>.
+  </p>
+</div>

--- a/_includes/buytickets.html
+++ b/_includes/buytickets.html
@@ -1,21 +1,9 @@
-<div class="md:grid md:grid-cols-2 md:gap-1">
-  <a
-    href="https://ti.to/goodscary/brightonruby-2026"
-    class="block w-full font-bold text-white bg-red-800 hover:bg-red-600 focus:outline-none focus:border-red-600 focus:shadow-outline-red active:bg-red-600 transition ease-in-out duration-150"
-  >
-    <div class="py-3 px-2 sm:p-4 text-center">
-      Buy Tickets
-      <span class="hidden sm:inline">for 2026</span>
-    </div>
-  </a>
-  <a
-    href="https://ti.to/goodscary/brighton-ruby-2026-brian-casel-workshop"
-    class="block w-full font-bold text-white bg-amber-700 hover:bg-amber-600 focus:outline-none focus:border-amber-600 focus:shadow-outline-amber active:bg-amber-600 transition ease-in-out duration-150"
-  >
-    <div class="py-3 px-2 sm:p-4 text-center">
-      AI Workshop
-      <span class="hidden md:inline">with Brian Casel</span>
-      <span class="hidden sm:inline">&mdash; 24th June</span>
-    </div>
-  </a>
-</div>
+<a
+  href="https://ti.to/goodscary/brightonruby-2026"
+  class="block w-full font-bold text-white bg-red-800 hover:bg-red-600 focus:outline-none focus:border-red-600 focus:shadow-outline-red active:bg-red-600 transition ease-in-out duration-150"
+>
+  <div class="py-3 px-2 sm:p-4 text-center">
+    Buy Tickets
+    <span class="hidden sm:inline">for 2026</span>
+  </div>
+</a>

--- a/_includes/twentytwentysix.html
+++ b/_includes/twentytwentysix.html
@@ -89,7 +89,7 @@
   <div class="container mt-2 px-2 sm:px-4 mx-auto">
     <div class="typography md:columns-2 mb-4">
       <p class="block h-auto max-w-full">
-        <a href="https://buildermethods.com">Brian</a> is the founder of Builder Methods and brings longtime Ruby, Rails, and SaaS experience, having built and sold multiple software products over the past decade. He'll explore what actually changes when experienced developers start building with AI — and what doesn't. Brian is also running a practical, hype-free <a href="https://ti.to/goodscary/brighton-ruby-2026-brian-casel-workshop">AI workshop on the 24th June</a>, the day before the conference, for just 20 attendees.
+        <a href="https://buildermethods.com">Brian</a> is the founder of Builder Methods and brings longtime Ruby, Rails, and SaaS experience, having built and sold multiple software products over the past decade. He'll explore what actually changes when experienced developers start building with AI — and what doesn't. Brian is also running a practical, hype-free AI workshop on the 24th June, the day before the conference, for just 20 attendees.
       </p>
       <p class="block h-auto max-w-full">
         <a href="https://elenatanasoiu.com/">Elena</a> & <a href="https://github.com/emmagabriel">Emma</a> from GitHub's Performance Engineering team will teach you how to read flamegraphs — the visualization that shows exactly where your code spends time. They'll demonstrate through a real production story where profiling a single page cut CPU consumption by 13%.


### PR DESCRIPTION
## Summary
- Remove the amber AI workshop button from the buy-tickets bar; the Buy Tickets button is back to full width.
- De-link the "AI workshop on the 24th June" mention in the 2026 speaker intro (the `Brian` → buildermethods.com link stays).
- Add a new schedule page at `/2026/schedule/` listing each session chronologically with time, headshot, linked title, and speaker. Breaks (Registration / Coffee / Lunch / Ice Cream / Drinks) are dimmed.

## Test plan
- [ ] Homepage top bar shows a single full-width red Buy Tickets button.
- [ ] Brian's intro paragraph reads as plain text for the workshop reference.
- [ ] `/2026/schedule/` renders in chronological order with breaks dimmed and talk titles linking to the talk pages.