### PR TITLE
Add robots.txt, sitemap.xml, and sitemap Link header

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,5 +8,6 @@ gem "benchmark"
 gem "html-proofer"
 gem "jekyll"
 gem "jekyll-redirect-from", group: [:jekyll_plugins]
+gem "jekyll-sitemap", group: [:jekyll_plugins]
 gem "jekyll-tailwindcss", group: [:jekyll_plugins]
 gem "jekyll-resize", git: "https://github.com/MichaelCurrin/jekyll-resize"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,8 @@ GEM
       jekyll (>= 3.3, < 5.0)
     jekyll-sass-converter (3.1.0)
       sass-embedded (~> 1.75)
+    jekyll-sitemap (1.4.0)
+      jekyll (>= 3.7, < 5.0)
     jekyll-tailwindcss (0.7.0)
       tailwindcss-ruby
     jekyll-watch (2.2.1)
@@ -232,6 +234,7 @@ DEPENDENCIES
   jekyll
   jekyll-redirect-from
   jekyll-resize!
+  jekyll-sitemap
   jekyll-tailwindcss
   logger
   webrick

--- a/_config.yml
+++ b/_config.yml
@@ -20,4 +20,5 @@ collections:
 plugins:
   - jekyll-redirect-from
   - jekyll-resize
+  - jekyll-sitemap
   - jekyll-tailwindcss

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,3 +5,4 @@
   for = "/*"
   [headers.values]
     Permissions-Policy = "interest-cohort=()"
+    Link = "<https://brightonruby.com/sitemap.xml>; rel=\"sitemap\"; type=\"application/xml\""

--- a/robots.txt
+++ b/robots.txt
@@ -2,21 +2,22 @@ User-agent: *
 Allow: /
 Disallow: /cache/
 
-# AI crawler policy — allow search/retrieval, disallow training corpus collection.
+# AI crawler policy — public marketing site; we want to be discoverable
+# in LLM answers and search, so training and retrieval are both allowed.
 User-agent: GPTBot
-Disallow: /
+Allow: /
 
 User-agent: Google-Extended
-Disallow: /
+Allow: /
 
 User-agent: ClaudeBot
-Disallow: /
+Allow: /
 
 User-agent: anthropic-ai
-Disallow: /
+Allow: /
 
 User-agent: CCBot
-Disallow: /
+Allow: /
 
 User-agent: PerplexityBot
 Allow: /
@@ -25,6 +26,6 @@ User-agent: OAI-SearchBot
 Allow: /
 
 # Cloudflare Content Signals (contentsignals.org)
-Content-Signal: search=yes, ai-train=no, ai-input=no
+Content-Signal: search=yes, ai-train=yes, ai-input=yes
 
 Sitemap: https://brightonruby.com/sitemap.xml

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,30 @@
+User-agent: *
+Allow: /
+Disallow: /cache/
+
+# AI crawler policy — allow search/retrieval, disallow training corpus collection.
+User-agent: GPTBot
+Disallow: /
+
+User-agent: Google-Extended
+Disallow: /
+
+User-agent: ClaudeBot
+Disallow: /
+
+User-agent: anthropic-ai
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+# Cloudflare Content Signals (contentsignals.org)
+Content-Signal: search=yes, ai-train=no, ai-input=no
+
+Sitemap: https://brightonruby.com/sitemap.xml


### PR DESCRIPTION
## Summary

Closes the realistic gaps from an [isitagentready.com](https://isitagentready.com) audit. Brighton Ruby is a static Jekyll/Netlify site that sells tickets — being discoverable in LLM answers and AI search is a feature, so the AI policy is permissive across the board. Most of the audit's other checks (API catalog, OAuth discovery, MCP server card, agent-skills index, WebMCP, Markdown content negotiation) intentionally don't apply to a static marketing site with no API, auth, or in-page tools.

- **`robots.txt`** — base allow + `/cache/` disallow, AI crawlers (GPTBot, Google-Extended, ClaudeBot, anthropic-ai, CCBot, PerplexityBot, OAI-SearchBot) all `Allow: /`, Cloudflare `Content-Signal: search=yes, ai-train=yes, ai-input=yes`, sitemap reference.
- **`sitemap.xml`** — `jekyll-sitemap` plugin auto-generates from posts, archives, and misc pages. 164 URLs anchored at `https://brightonruby.com`.
- **`Link` header** — `netlify.toml` advertises `</sitemap.xml>; rel="sitemap"; type="application/xml"` on `/*` per RFC 8288.

## Test plan

- [x] `bundle exec jekyll build` clean
- [x] `_site/robots.txt` and `_site/sitemap.xml` present and well-formed
- [x] htmlproofer baseline unchanged (same 399 pre-existing failures as `main`)
- [ ] Post-deploy: `curl -sI https://brightonruby.com/ | grep -i ^link` shows the sitemap Link header
- [ ] Post-deploy: re-run isitagentready.com and confirm robots.txt / sitemap / Link / AI rules / Content Signals checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)