### PR TITLE
Commit wrangler.jsonc to skip auto-config rebuild

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,8 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "brightonruby-com",
+  "compatibility_date": "2026-05-03",
+  "assets": {
+    "directory": "_site"
+  }
+}


### PR DESCRIPTION
## Summary

Pin a static \`wrangler.jsonc\` so \`npx wrangler deploy\` treats this as a Workers static-assets project and skips the auto-detect path that would otherwise re-run \`npx bundle exec jekyll build\` (which fails because npx can't resolve \`bundle\`). Use this branch only if the Cloudflare deploy command is set to \`npx wrangler deploy\`; if it is set to \`npx wrangler pages deploy\`, this file is unused.

## Test plan

- [ ] Cloudflare deploy command set to \`npx wrangler deploy\`
- [ ] Build + deploy succeed; site published at brightonruby.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)