### PR TITLE
Fix unstyled deploy: force UTF-8 locale for Jekyll build

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Cloudflare's build container does not set a UTF-8 locale, which makes
+# jekyll-tailwindcss silently fail with "invalid byte sequence in US-ASCII"
+# when scanning post bodies that contain apostrophes or accented characters.
+# When that happens the plugin emits no compiled CSS and Jekyll copies the
+# raw `@import "tailwindcss"` source to _site/, leaving the deployed site
+# unstyled.
+export LANG=C.UTF-8
+export LC_ALL=C.UTF-8
+
+exec bundle exec jekyll build "$@"


### PR DESCRIPTION
## Summary

The deployed site at https://brightonruby-com.andy-95b.workers.dev/ is rendering unstyled because Cloudflare is serving the raw 585-byte Tailwind source (`@import \"tailwindcss\"`) instead of the compiled 48 KB CSS. Cloudflare's build container does not set a UTF-8 locale, so \`jekyll-tailwindcss\` silently fails with \`invalid byte sequence in US-ASCII\` while scanning post bodies (apostrophes, accented author names), emits no compiled CSS, and Jekyll then copies the source \`assets/css/app.css\` straight through to \`_site/\`. Reproduced locally with \`LANG=C\`. This adds \`bin/build\` which exports \`LANG=C.UTF-8\` and \`LC_ALL=C.UTF-8\` before invoking Jekyll, so the locale fix is versioned in the repo.

## Test plan

- [x] \`LANG=C ./bin/build\` produces a 48 KB compiled \`_site/assets/css/app.css\` (vs 585 B without the wrapper)
- [ ] Update Cloudflare build command to \`bin/build\` (was: \`bundle exec jekyll build\`)
- [ ] After deploy, https://brightonruby-com.andy-95b.workers.dev/assets/css/app.css starts with \`/*! tailwindcss v4.1.13 ...\` and the homepage renders styled

🤖 Generated with [Claude Code](https://claude.com/claude-code)