### PR TITLE
Add manual GitHub Actions workflow to redeploy main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,33 @@
+name: Deploy
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Build site
+        env:
+          JEKYLL_ENV: production
+          LANG: C.UTF-8
+          LC_ALL: C.UTF-8
+        run: bundle exec jekyll build
+
+      - name: Deploy to Cloudflare
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy


### PR DESCRIPTION
## Summary

Adds a \`workflow_dispatch\`-only workflow that manually rebuilds and redeploys the latest \`main\` to the \`brightonruby-com\` Worker via \`wrangler deploy\`. The build runs under a UTF-8 locale so \`jekyll-tailwindcss\` emits the compiled CSS rather than the raw \`@import \"tailwindcss\"\` source.

## Setup

Add two repository secrets before first run (Settings → Secrets and variables → Actions):

- \`CLOUDFLARE_API_TOKEN\` — Workers Scripts:Edit on the \`brightonruby-com\` Worker
- \`CLOUDFLARE_ACCOUNT_ID\` — \`95ba69077f008cedb2b446ca19ffdf98\`

## Test plan

- [ ] Add the two secrets above
- [ ] Actions tab → Deploy → Run workflow → main → run completes green
- [ ] https://brightonruby-com.andy-95b.workers.dev/assets/css/app.css starts with \`/*! tailwindcss v4.1.13\` and the homepage renders styled

🤖 Generated with [Claude Code](https://claude.com/claude-code)