### PR TITLE
Route raster images through cf_image helper

### DIFF
--- a/_includes/cf_image.html
+++ b/_includes/cf_image.html
@@ -9,13 +9,18 @@ Params:
   height (optional) — pixels
   fit    (optional) — Cloudflare fit mode, defaults to "cover"
 {%- endcomment -%}
+{%- assign src = include.src -%}
+{%- unless src contains "://" -%}
+{%- assign first_char = src | slice: 0 -%}
+{%- unless first_char == "/" -%}{%- assign src = "/" | append: src -%}{%- endunless -%}
+{%- endunless -%}
 {%- if jekyll.environment == "production" -%}
 {%- assign opts = "format=auto" -%}
 {%- if include.width -%}{%- assign opts = opts | append: ",width=" | append: include.width -%}{%- endif -%}
 {%- if include.height -%}{%- assign opts = opts | append: ",height=" | append: include.height -%}{%- endif -%}
 {%- assign fit = include.fit | default: "cover" -%}
 {%- if include.width or include.height -%}{%- assign opts = opts | append: ",fit=" | append: fit -%}{%- endif -%}
-/cdn-cgi/image/{{ opts }}{{ include.src }}
+/cdn-cgi/image/{{ opts }}{{ src }}
 {%- else -%}
-{{ include.src }}
+{{ src }}
 {%- endif -%}

--- a/_includes/twentytwentyfive.html
+++ b/_includes/twentytwentyfive.html
@@ -2,84 +2,84 @@
   <div class="grid grid-cols-6 xl:grid-cols-12 gap-4 container mx-auto my-4">
     <a href="https://rosa.codes">
       <img
-        src="/images/2025/speakers/rosa_gutierrez.jpg"
+        src="{% include cf_image.html src='/images/2025/speakers/rosa_gutierrez.jpg' width=192 height=192 %}"
         class="w-auto aspect-1/1 rounded-sm"
         alt="Rosa Gutiérrez"
       >
     </a>
     <a href="https://www.linkedin.com/in/vwoolard/">
       <img
-        src="/images/2025/speakers/valerie_woolard.jpg"
+        src="{% include cf_image.html src='/images/2025/speakers/valerie_woolard.jpg' width=192 height=192 %}"
         class="w-auto aspect-1/1 rounded-sm"
         alt="Valerie Woolard"
       >
     </a>
     <a href="https://julialopez.dev">
       <img
-        src="/images/2025/speakers/julia_lopez.jpg"
+        src="{% include cf_image.html src='/images/2025/speakers/julia_lopez.jpg' width=192 height=192 %}"
         class="w-auto aspect-1/1 rounded-sm"
         alt="Julia López"
       >
     </a>
     <a href="https://emilysamp.dev">
       <img
-        src="/images/2025/speakers/emily_samp.jpg"
+        src="{% include cf_image.html src='/images/2025/speakers/emily_samp.jpg' width=192 height=192 %}"
         class="w-auto aspect-1/1 rounded-sm"
         alt="Emily Samp"
       >
     </a>
     {% comment %} <a href="https://rubytshirts.com/products/brighton-ruby-25"> {% endcomment %}
     <img
-      src="/images/2025/speakers/brighton_ruby.png"
+      src="{% include cf_image.html src='/images/2025/speakers/brighton_ruby.png' width=192 height=192 %}"
       class="w-auto aspect-1/1 rounded-sm"
       alt="Get a t-shirt"
     >
     {% comment %} </a> {% endcomment %}
     <a href="https://www.linkedin.com/in/harrietoughton21/">
       <img
-        src="/images/2025/speakers/harriet_oughton.jpg"
+        src="{% include cf_image.html src='/images/2025/speakers/harriet_oughton.jpg' width=192 height=192 %}"
         class="w-auto aspect-1/1 rounded-sm"
         alt="Harriet Oughton"
       >
     </a>
     <a href="https://www.linkedin.com/in/amandabrookeperino/">
       <img
-        src="/images/2025/speakers/amanda_perino.jpg"
+        src="{% include cf_image.html src='/images/2025/speakers/amanda_perino.jpg' width=192 height=192 %}"
         class="w-auto aspect-1/1 rounded-sm"
         alt="Amanda Perino"
       >
     </a>
     <a href="https://nadiaodunayo.com">
       <img
-        src="/images/2025/speakers/nadia_odunayo.jpg"
+        src="{% include cf_image.html src='/images/2025/speakers/nadia_odunayo.jpg' width=192 height=192 %}"
         class="w-auto aspect-1/1 rounded-sm"
         alt="Nadia Odunayo"
       >
     </a>
     <a href="https://amyhupe.co.uk">
       <img
-        src="/images/2025/speakers/amy_hupe.jpg"
+        src="{% include cf_image.html src='/images/2025/speakers/amy_hupe.jpg' width=192 height=192 %}"
         class="w-auto aspect-1/1 rounded-sm"
         alt="Amy Hupe"
       >
     </a>
     <a href="https://www.linkedin.com/in/myudina/">
       <img
-        src="/images/2025/speakers/maria_yudina.jpg"
+        src="{% include cf_image.html src='/images/2025/speakers/maria_yudina.jpg' width=192 height=192 %}"
         class="w-auto aspect-1/1 rounded-sm"
         alt="Maria Yudina"
       >
     </a>
     <a href="https://linkedin.com/in/carme-mias">
       <img
-        src="/images/2025/speakers/carme_mias.jpg"
+        src="{% include cf_image.html src='/images/2025/speakers/carme_mias.jpg' width=192 height=192 %}"
         class="w-auto aspect-1/1 rounded-sm"
         alt="Carme Mias"
       >
     </a>
     <a href="https://www.linkedin.com/in/jess-sullivan-1ab72ba1/">
       <img
-        src="/images/2025/speakers/jess_sullivan.jpg"
+        src="{% include cf_image.html src='/images/2025/speakers/jess_sullivan.jpg' width=192 height=192 %}"
         class="w-auto aspect-1/1 rounded-sm"
         alt="Jess Sullivan"
       >

--- a/_includes/twentytwentyfour.html
+++ b/_includes/twentytwentyfour.html
@@ -10,7 +10,7 @@
   <div class="lg:grid lg:grid-cols-2 gap-8 container mx-auto px-2 sm:px-4">
     <div class="prose lg:ml-4">
       <img
-        src="/images/2024/speakers/nadia_odunayo.jpg"
+        src="{% include cf_image.html src='/images/2024/speakers/nadia_odunayo.jpg' width=192 height=192 %}"
         class="w-16 md:w-20 lg:w-24 mt-0 mb-4 mr-4 aspect-1/1 rounded-sm float-left"
         alt="Nadia Odunayo"
       >
@@ -22,7 +22,7 @@
         framework”.
       </p>
       <img
-        src="/images/2024/speakers/nicky_thompson.jpg"
+        src="{% include cf_image.html src='/images/2024/speakers/nicky_thompson.jpg' width=192 height=192 %}"
         class="w-16 md:w-20 lg:w-24 mt-0 mb-4 ml-4 aspect-1/1 rounded-sm float-right"
         alt="Nicky Thompson"
       >
@@ -33,7 +33,7 @@
         research into providing us all with ways to make better, smarter decisions.
       </p>
       <img
-        src="/images/2024/speakers/mohamed_hassan.jpg"
+        src="{% include cf_image.html src='/images/2024/speakers/mohamed_hassan.jpg' width=192 height=192 %}"
         class="w-16 md:w-20 lg:w-24 mt-0 mb-4 mr-4 aspect-1/1 rounded-sm float-left"
         alt="Mohamed Hassan"
       >
@@ -43,7 +43,7 @@
         <a href="https://oldmoe.blog">Mohamed Hassan</a>.
       </p>
       <img
-        src="/images/2024/speakers/daniel_vartanov.jpg"
+        src="{% include cf_image.html src='/images/2024/speakers/daniel_vartanov.jpg' width=192 height=192 %}"
         class="w-16 md:w-20 lg:w-24 mt-0 mb-4 ml-4 aspect-1/1 rounded-sm float-right"
         alt="Daniel Vartanov"
       >
@@ -53,7 +53,7 @@
       </p>
 
       <img
-        src="/images/2024/speakers/karen_jex.jpg"
+        src="{% include cf_image.html src='/images/2024/speakers/karen_jex.jpg' width=192 height=192 %}"
         class="w-16 md:w-20 lg:w-24 mt-0 mb-4 mr-4 aspect-1/1 rounded-sm float-left"
         alt="Karen Jex"
       >
@@ -65,7 +65,7 @@
     </div>
     <div class="prose mt-6 lg:mt-0 lg:mr-4">
       <img
-        src="/images/2024/speakers/chris_oliver.jpg"
+        src="{% include cf_image.html src='/images/2024/speakers/chris_oliver.jpg' width=192 height=192 %}"
         class="w-16 md:w-20 lg:w-24 mt-0 mb-4 mr-4 aspect-1/1 rounded-sm float-left"
         alt="Chris Oliver"
       >
@@ -82,27 +82,27 @@
       </p>
       <div class="grid grid-cols-5 gap-4 mt-6 mb-0 max-w-sm md:max-w-md">
         <img
-          src="/images/2024/speakers/matt_rayner.jpg"
+          src="{% include cf_image.html src='/images/2024/speakers/matt_rayner.jpg' width=192 height=192 %}"
           class="w-auto mt-0 mb-4 mr-4 aspect-1/1 rounded-sm"
           alt="Matt Rayner"
         >
         <img
-          src="/images/2024/speakers/frederic_wong.jpg"
+          src="{% include cf_image.html src='/images/2024/speakers/frederic_wong.jpg' width=192 height=192 %}"
           class="w-auto mt-0 mb-4 mr-4 aspect-1/1 rounded-sm"
           alt="Frederic Wong"
         >
         <img
-          src="/images/2024/speakers/murad_iusufov.jpg"
+          src="{% include cf_image.html src='/images/2024/speakers/murad_iusufov.jpg' width=192 height=192 %}"
           class="w-auto mt-0 mb-4 mr-4 aspect-1/1 rounded-sm"
           alt="Murad Iusufov"
         >
         <img
-          src="/images/2024/speakers/richard_brooke.jpg"
+          src="{% include cf_image.html src='/images/2024/speakers/richard_brooke.jpg' width=192 height=192 %}"
           class="w-auto mt-0 mb-4 mr-4 aspect-1/1 rounded-sm"
           alt="Richard Brooke"
         >
         <img
-          src="/images/2024/speakers/chris_howlett.jpg"
+          src="{% include cf_image.html src='/images/2024/speakers/chris_howlett.jpg' width=192 height=192 %}"
           class="w-auto mt-0 mb-4 mr-4 aspect-1/1 rounded-sm"
           alt="Chris Howlett"
         >
@@ -110,7 +110,7 @@
       <p class="mt-0">Matt, Frederic, Murad, Richard &amp; Chris will be sharing the stage.</p>
 
       <img
-        src="/images/2024/speakers/marco_roth.jpg"
+        src="{% include cf_image.html src='/images/2024/speakers/marco_roth.jpg' width=192 height=192 %}"
         class="w-16 md:w-20 lg:w-24 mt-0 mb-4 ml-4 aspect-1/1 rounded-sm float-right"
         alt="Marco Roth"
       >
@@ -122,7 +122,7 @@
       </p>
 
       <img
-        src="/images/2024/speakers/drew_bragg.jpg"
+        src="{% include cf_image.html src='/images/2024/speakers/drew_bragg.jpg' width=192 height=192 %}"
         class="w-16 md:w-20 lg:w-24 mt-0 mb-4 mr-4 aspect-1/1 rounded-sm float-left"
         alt="Drew Bragg"
       >

--- a/_includes/twentytwentysix.html
+++ b/_includes/twentytwentysix.html
@@ -2,84 +2,84 @@
   <div class="grid grid-cols-4 md:grid-cols-6 gap-4 container mx-auto my-4 px-2 sm:px-4">
     <a href="https://buildermethods.com">
       <img
-        src="/images/2026/speakers/brian_casel.jpg"
+        src="{% include cf_image.html src='/images/2026/speakers/brian_casel.jpg' width=192 height=192 %}"
         class="w-full aspect-square object-cover rounded-sm"
         alt="Brian Casel"
       >
     </a>
     <a href="https://elenatanasoiu.com/">
       <img
-        src="/images/2026/speakers/elena_tanasoiu.jpg"
+        src="{% include cf_image.html src='/images/2026/speakers/elena_tanasoiu.jpg' width=192 height=192 %}"
         class="w-full aspect-square object-cover rounded-sm"
         alt="Elena Tanasoiu"
       >
     </a>
     <a href="https://github.com/emmagabriel">
       <img
-        src="/images/2026/speakers/emma_gabriel.jpg"
+        src="{% include cf_image.html src='/images/2026/speakers/emma_gabriel.jpg' width=192 height=192 %}"
         class="w-full aspect-square object-cover rounded-sm"
         alt="Emma Gabriel"
       >
     </a>
     <a href="https://github.com/CraigDoesCode">
       <img
-        src="/images/2026/speakers/craig_norford.png"
+        src="{% include cf_image.html src='/images/2026/speakers/craig_norford.png' width=192 height=192 %}"
         class="w-full aspect-square object-cover rounded-sm"
         alt="Craig Norford"
       >
     </a>
     <a href="https://www.linkedin.com/in/ihadzhiatanasova/">
       <img
-        src="/images/2026/speakers/iliana_hadzhiatanasova.jpg"
+        src="{% include cf_image.html src='/images/2026/speakers/iliana_hadzhiatanasova.jpg' width=192 height=192 %}"
         class="w-full aspect-square object-cover rounded-sm"
         alt="Iliana Hadzhiatanasova"
       >
     </a>
     <a href="https://alexcwatt.com/">
       <img
-        src="/images/2026/speakers/alex_watt.jpg"
+        src="{% include cf_image.html src='/images/2026/speakers/alex_watt.jpg' width=192 height=192 %}"
         class="w-full aspect-square object-cover rounded-sm"
         alt="Alex Watt"
       >
     </a>
     <a href="https://github.com/rhannequin">
       <img
-        src="/images/2026/speakers/remy_hannequin.jpg"
+        src="{% include cf_image.html src='/images/2026/speakers/remy_hannequin.jpg' width=192 height=192 %}"
         class="w-full aspect-square object-cover rounded-sm"
         alt="Rémy Hannequin"
       >
     </a>
     <a href="https://www.linkedin.com/in/myudina/">
       <img
-        src="/images/2026/speakers/maria_yudina.jpg"
+        src="{% include cf_image.html src='/images/2026/speakers/maria_yudina.jpg' width=192 height=192 %}"
         class="w-full aspect-square object-cover rounded-sm"
         alt="Maria Yudina"
       >
     </a>
     <a href="https://tekin.co.uk">
       <img
-        src="/images/2026/speakers/tekin_suleyman.jpg"
+        src="{% include cf_image.html src='/images/2026/speakers/tekin_suleyman.jpg' width=192 height=192 %}"
         class="w-full aspect-square object-cover rounded-sm"
         alt="Tekin Süleyman"
       >
     </a>
     <a href="https://github.com/tijmenb">
       <img
-        src="/images/2026/speakers/tijmen_brommet.jpg"
+        src="{% include cf_image.html src='/images/2026/speakers/tijmen_brommet.jpg' width=192 height=192 %}"
         class="w-full aspect-square object-cover rounded-sm"
         alt="Tijmen Brommet"
       >
     </a>
     <a href="https://www.linkedin.com/in/jennie1evans/">
       <img
-        src="/images/2026/speakers/jennie_evans.jpg"
+        src="{% include cf_image.html src='/images/2026/speakers/jennie_evans.jpg' width=192 height=192 %}"
         class="w-full aspect-square object-cover rounded-sm"
         alt="Jennie Evans"
       >
     </a>
     <a href="https://andycroll.com">
       <img
-        src="/images/2026/speakers/andy_croll.jpg"
+        src="{% include cf_image.html src='/images/2026/speakers/andy_croll.jpg' width=192 height=192 %}"
         class="w-full aspect-square object-cover rounded-sm"
         alt="Andy Croll"
       >

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,13 +11,16 @@
 
   {% assign page_author = site.data.authors[page.author] %}
   {% assign page_image = page.image %}
+  {% if page_image %}
+    {% capture page_image_url %}{% include cf_image.html src=page_image width=1200 height=630 %}{% endcapture %}
+  {% endif %}
 
   <meta property="og:title" content="{{ page.title }}">
   <meta property="og:description" content="{{ page.description }}">
   <meta property="og:site_name" content="{{ site.name }}">
   <meta property="og:type" content="article">
   {% if page_image %}
-  <meta property="og:image" content="{{ page.image | absolute_url }}">
+  <meta property="og:image" content="{{ page_image_url | absolute_url }}">
   {% endif %}
 
   <meta name="twitter:site" content="@brightonruby">
@@ -30,7 +33,7 @@
   <meta name="twitter:description" content="{{ page.description }}">
   {% if page_image %}
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:image" content="{{ page.image | absolute_url }}">
+  <meta name="twitter:image" content="{{ page_image_url | absolute_url }}">
   {% endif %}
 
   <link rel="stylesheet" href="{{ "/assets/css/monolisa.css" | relative_url }}">

--- a/_layouts/video.html
+++ b/_layouts/video.html
@@ -58,7 +58,7 @@ layout: default
         preload="metadata"
         controls
         autoPictureInPicture
-        poster="{{ page.image }}"
+        poster="{% if page.image %}{% include cf_image.html src=page.image width=1280 height=800 %}{% endif %}"
       >
         <source src="//{{ page.video_source }}" type="video/mp4">
         <!-- <track label="English" kind="subtitles" srclang="en-us" src="JAWS-aria-errors.vtt" default=""> -->

--- a/_misc/lovely-brighton.markdown
+++ b/_misc/lovely-brighton.markdown
@@ -66,7 +66,7 @@ Grassy area just north of the North Laine. Skate park (lookout for men who are '
 
 [Visit Brighton](http://www.visitbrighton.com) a standard 'tourist-y' site - to cover stuff I haven’t seen or done.
 
-<img src="/images/brightonmap.png" class="img-fluid" alt="Brighton Central Areas" />
+<img src="{% include cf_image.html src='/images/brightonmap.png' %}" class="img-fluid" alt="Brighton Central Areas" />
 
 And there's the regular standby of Yelp: their coverage seems pretty accurate.
 


### PR DESCRIPTION
## Summary

- Wrap all raster `<img>` tags (2024/2025/2026 speaker grids, OG/Twitter social card, video poster, Brighton map) with `{% include cf_image.html %}` so production traffic gets `format=auto` (AVIF/WebP) and per-image resizing via Cloudflare Image Transformations. Dev keeps raw `/images/...` paths.
- Harden `cf_image.html` to prepend a leading `/` when `src` is missing one, so legacy frontmatter like `image: 'images/twitter-image.jpg'` still produces valid URLs.
- SVG sponsor logos and the site logo are intentionally left raw — they're vector and don't benefit.

## Test plan

- [x] `JEKYLL_ENV=production bundle exec jekyll build` — verified all speaker images, social cards, video posters, and the map render as `/cdn-cgi/image/format=auto,…/images/…`
- [x] `bundle exec jekyll build` (dev) — verified raw `/images/…` paths preserved, zero `cdn-cgi` strings
- [ ] Spot-check a deployed page in the browser to confirm Cloudflare returns AVIF/WebP

🤖 Generated with [Claude Code](https://claude.com/claude-code)