### PR TITLE
perf(images): Inline sponsor and logo SVGs at build time

### DIFF
--- a/_includes/gold.html
+++ b/_includes/gold.html
@@ -4,6 +4,7 @@
       <p class="text-xs opacity-40 text-center">Sponsored by...</p>
       <div class="flex flex-wrap items-center justify-center gap-x-8 sm:gap-x-12 gap-y-6 pt-2">
         {% for sponsor in page.gold %}
+          {% assign sponsor_slug = sponsor.name | downcase | replace: ' ', '_' %}
           {% if sponsor.url != null %}
             <a
               class="block"
@@ -11,19 +12,11 @@
               title="{{ sponsor.name }}"
               target="_blank"
             >
-              <img
-                class="h-12 sm:h-16 md:h-18 w-auto"
-                src="/images/2026/sponsors/{{ sponsor.name | downcase | replace: ' ', '_'}}.svg"
-                alt="{{ sponsor.name }} Logo"
-              >
+              {% inline_svg /images/2026/sponsors/{{ sponsor_slug }}.svg class="h-12 sm:h-16 md:h-18 w-auto" role="img" aria-label="{{ sponsor.name }} Logo" %}
             </a>
           {% else %}
             <div class="block">
-              <img
-                class="h-12 sm:h-16 md:h-18 w-auto"
-                src="/images/2026/sponsors/{{ sponsor.name | downcase | replace: ' ', '_'}}.svg"
-                alt="{{ sponsor.name }} Logo"
-              >
+              {% inline_svg /images/2026/sponsors/{{ sponsor_slug }}.svg class="h-12 sm:h-16 md:h-18 w-auto" role="img" aria-label="{{ sponsor.name }} Logo" %}
             </div>
           {% endif %}
         {% endfor %}

--- a/_includes/silver.html
+++ b/_includes/silver.html
@@ -3,6 +3,7 @@
 
   <div class="w-full flex flex-wrap lg:flex-nowrap justify-center mx-auto">
     {% for sponsor in page.silver %}
+      {% assign sponsor_slug = sponsor.name | downcase | replace: ' ', '_' %}
       {% if sponsor.url != null %}
         <a
           class="w-32 md:w-40 p-2 px-4"
@@ -10,18 +11,10 @@
           title="{{ sponsor.name }}"
           target="_blank"
         >
-          <img
-            class=""
-            src="/images/2025/sponsors/{{ sponsor.name | downcase | replace: ' ', '_'}}.svg"
-            alt="{{ sponsor.name }} Logo"
-          >
+          {% inline_svg /images/2025/sponsors/{{ sponsor_slug }}.svg role="img" aria-label="{{ sponsor.name }} Logo" %}
         </a>
       {% else %}
-        <img
-          class="w-32 md:w-40 p-2 px-4"
-          src="/images/2025/sponsors/{{ sponsor.name | downcase | replace: ' ', '_'}}.svg"
-          alt="{{ sponsor.name }} Logo"
-        >
+        {% inline_svg /images/2025/sponsors/{{ sponsor_slug }}.svg class="w-32 md:w-40 p-2 px-4" role="img" aria-label="{{ sponsor.name }} Logo" %}
       {% endif %}
     {% endfor %}
   </div>

--- a/_includes/supporters.html
+++ b/_includes/supporters.html
@@ -4,6 +4,7 @@
       <p class="text-xs opacity-40 text-center">Supporters</p>
       <div class="flex flex-wrap items-center justify-center gap-x-6 sm:gap-x-8 gap-y-4 pt-2 max-w-5xl mx-auto">
         {% for sponsor in page.supporters %}
+          {% assign sponsor_slug = sponsor.name | downcase | replace: ' ', '_' %}
           {% if sponsor.url != null %}
             <a
               class="block"
@@ -11,19 +12,11 @@
               title="{{ sponsor.name }}"
               target="_blank"
             >
-              <img
-                class="h-7 sm:h-8 md:h-9 w-auto"
-                src="/images/2026/sponsors/{{ sponsor.name | downcase | replace: ' ', '_'}}.svg"
-                alt="{{ sponsor.name }} Logo"
-              >
+              {% inline_svg /images/2026/sponsors/{{ sponsor_slug }}.svg class="h-7 sm:h-8 md:h-9 w-auto" role="img" aria-label="{{ sponsor.name }} Logo" %}
             </a>
           {% else %}
             <div class="block">
-              <img
-                class="h-7 sm:h-8 md:h-9 w-auto"
-                src="/images/2026/sponsors/{{ sponsor.name | downcase | replace: ' ', '_'}}.svg"
-                alt="{{ sponsor.name }} Logo"
-              >
+              {% inline_svg /images/2026/sponsors/{{ sponsor_slug }}.svg class="h-7 sm:h-8 md:h-9 w-auto" role="img" aria-label="{{ sponsor.name }} Logo" %}
             </div>
           {% endif %}
         {% endfor %}

--- a/_layouts/archive.html
+++ b/_layouts/archive.html
@@ -77,20 +77,13 @@ layout: default
 
           <div class="grow grid grid-cols-3 sm:grid-cols-4 content-center gap-2 gap-x-4 md:gap-4">
             {% for sponsor in page.gold %}
+              {% assign sponsor_slug = sponsor.name | downcase | replace: ' ', '_' %}
               {% if sponsor.url != null %}
                 <a class="block" href="{{ sponsor.url }}" title="{{ sponsor.name }}" target="_blank">
-                  <img
-                    class="block"
-                    src="/images/{{ page_year }}/sponsors/{{ sponsor.name | downcase | replace: ' ', '_'}}.svg"
-                    alt="{{ sponsor.name }} Logo"
-                  >
+                  {% inline_svg /images/{{ page_year }}/sponsors/{{ sponsor_slug }}.svg class="block" role="img" aria-label="{{ sponsor.name }} Logo" %}
                 </a>
               {% else %}
-                <img
-                  class="block"
-                  src="/images/{{ page_year }}/sponsors/{{ sponsor.name | downcase | replace: ' ', '_'}}.svg"
-                  alt="{{ sponsor.name }} Logo"
-                >
+                {% inline_svg /images/{{ page_year }}/sponsors/{{ sponsor_slug }}.svg class="block" role="img" aria-label="{{ sponsor.name }} Logo" %}
               {% endif %}
             {% endfor %}
           </div>
@@ -104,20 +97,13 @@ layout: default
 
             <div class="grow grid grid-cols-3 sm:grid-cols-4 content-center gap-2 gap-x-4 md:gap-4">
               {% for sponsor in page.silver %}
+                {% assign sponsor_slug = sponsor.name | downcase | replace: ' ', '_' %}
                 {% if sponsor.url != null %}
                   <a class="block" href="{{ sponsor.url }}" title="{{ sponsor.name }}" target="_blank">
-                    <img
-                      class="block"
-                      src="/images/{{ page_year }}/sponsors/{{ sponsor.name | downcase | replace: ' ', '_'}}.svg"
-                      alt="{{ sponsor.name }} Logo"
-                    >
+                    {% inline_svg /images/{{ page_year }}/sponsors/{{ sponsor_slug }}.svg class="block" role="img" aria-label="{{ sponsor.name }} Logo" %}
                   </a>
                 {% else %}
-                  <img
-                    class="block"
-                    src="/images/{{ page_year }}/sponsors/{{ sponsor.name | downcase | replace: ' ', '_'}}.svg"
-                    alt="{{ sponsor.name }} Logo"
-                  >
+                  {% inline_svg /images/{{ page_year }}/sponsors/{{ sponsor_slug }}.svg class="block" role="img" aria-label="{{ sponsor.name }} Logo" %}
                 {% endif %}
               {% endfor %}
             </div>
@@ -150,20 +136,13 @@ layout: default
 
           <div class="grow grid grid-cols-3 sm:grid-cols-4 content-center gap-2 gap-x-4 md:gap-4">
             {% for sponsor in page.supporter %}
+              {% assign sponsor_slug = sponsor.name | downcase | replace: ' ', '_' %}
               {% if sponsor.url != null %}
                 <a class="block" href="{{ sponsor.url }}" title="{{ sponsor.name }}" target="_blank">
-                  <img
-                    class="block object-contain"
-                    src="/images/{{ page_year }}/sponsors/{{ sponsor.name | downcase | replace: ' ', '_'}}.svg"
-                    alt="{{ sponsor.name }} Logo"
-                  >
+                  {% inline_svg /images/{{ page_year }}/sponsors/{{ sponsor_slug }}.svg class="block object-contain" role="img" aria-label="{{ sponsor.name }} Logo" %}
                 </a>
               {% else %}
-                <img
-                  class="block"
-                  src="/images/{{ page_year }}/sponsors/{{ sponsor.name | downcase | replace: ' ', '_'}}.svg"
-                  alt="{{ sponsor.name }} Logo"
-                >
+                {% inline_svg /images/{{ page_year }}/sponsors/{{ sponsor_slug }}.svg class="block" role="img" aria-label="{{ sponsor.name }} Logo" %}
               {% endif %}
             {% endfor %}
           </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -47,7 +47,7 @@
       <div class="h-auto sm:h-20 px-2 sm:px-4">
         <div class="flex flex-col sm:flex-row">
           <a class="inline-block flex sm:grow" href="/">
-            <img src="/images/logo.svg" class="py-4 w-auto sm:h-20" alt="Brighton Ruby Conference Logo" />
+            {% inline_svg /images/logo.svg class="py-4 w-auto sm:h-20" role="img" aria-label="Brighton Ruby Conference Logo" %}
           </a>
 
           <h1 class="sm:grow sm:text-right font-bold italic pb-3 sm:py-3 flex flex-row sm:flex-col">

--- a/_plugins/inline_svg.rb
+++ b/_plugins/inline_svg.rb
@@ -1,0 +1,57 @@
+module Jekyll
+  class InlineSvgTag < Liquid::Tag
+    ATTR_PATTERN = /(?<key>[\w-]+)="(?<value>[^"]*)"/.freeze
+
+    def initialize(tag_name, markup, tokens)
+      super
+      @markup = markup.strip
+    end
+
+    def render(context)
+      rendered = Liquid::Template.parse(@markup).render(context).strip
+      path, attrs = parse_markup(rendered)
+
+      site_source = context.registers[:site].source
+      full_path = File.join(site_source, path.sub(%r{\A/}, ""))
+
+      raise ArgumentError, "inline_svg: file not found: #{path}" unless File.exist?(full_path)
+
+      svg = File.read(full_path)
+      svg = svg.sub(/\A\s*<\?xml.*?\?>\s*/m, "")
+      svg = svg.sub(/\A\s*<!DOCTYPE.*?>\s*/m, "")
+      svg = svg.strip
+
+      inject_attrs(svg, attrs)
+    end
+
+    private
+
+    def parse_markup(rendered)
+      path, rest = rendered.split(/\s+/, 2)
+      attrs = rest ? rest.scan(ATTR_PATTERN).to_h : {}
+      [path, attrs]
+    end
+
+    def inject_attrs(svg, attrs)
+      return svg if attrs.empty?
+
+      svg.sub(/<svg\b([^>]*)>/) do
+        existing = Regexp.last_match(1).to_s
+        merged = attrs.reduce(existing) do |acc, (key, value)|
+          if acc =~ /\b#{Regexp.escape(key)}="([^"]*)"/
+            acc.sub(/\b#{Regexp.escape(key)}="([^"]*)"/) do
+              prev = Regexp.last_match(1)
+              combined = key == "class" ? "#{prev} #{value}".strip : value
+              %Q(#{key}="#{combined}")
+            end
+          else
+            "#{acc} #{key}=\"#{value}\""
+          end
+        end
+        "<svg#{merged}>"
+      end
+    end
+  end
+end
+
+Liquid::Template.register_tag("inline_svg", Jekyll::InlineSvgTag)


### PR DESCRIPTION
A new \`_plugins/inline_svg.rb\` Liquid tag reads SVG files at build time and emits them as inline \`<svg>\` with \`class\` merged onto whatever's already on the root and \`role\`/\`aria-label\` added in place of the old \`<img alt>\`.

Every site logo and gold/silver/supporter sponsor logo is now inlined — `_layouts/default.html`, the three sponsor includes, and the archive layout. That drops the per-image SVG request on every page (logo) and ~12 sponsor requests on the homepage, plus each archive year's sponsors. Raster handling is untouched and still flows through `cf_image`.

Verified locally with `bundle exec jekyll build` (dev + `JEKYLL_ENV=production`), screenshot diffing of `/` and `/2025/`, and `htmlproofer` (failure count unchanged vs. baseline; no new SVG-related errors).

---

[![Compound Engineering v2.54.1](https://img.shields.io/badge/Compound_Engineering-v2.54.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.7 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)