### PR TITLE
Show 2026 schedule on the home page

### DIFF
--- a/_posts/2026/2026-06-25-10-cool-things-internationalisation-tekin-suleyman.md
+++ b/_posts/2026/2026-06-25-10-cool-things-internationalisation-tekin-suleyman.md
@@ -10,7 +10,7 @@ author_social:
     url: "https://bsky.app/profile/tekin.co.uk"
   - name: "@tekin@ruby.social"
     url: "https://ruby.social/@tekin"
-layout: video
+layout: preview
 author_image: "/images/2026/speakers/tekin_suleyman.jpg"
 description: "10 cool things you probably didn't know about internationalisation."
 ---

--- a/_posts/2026/2026-06-25-code-prompts-and-stories-maria-yudina.md
+++ b/_posts/2026/2026-06-25-code-prompts-and-stories-maria-yudina.md
@@ -6,7 +6,7 @@ author_bio_markdown: "Software Engineer at Shopify with experience across startu
 author_social:
   - name: "GitHub"
     url: "https://github.com/mariayudina"
-layout: video
+layout: preview
 author_image: "/images/2026/speakers/maria_yudina.jpg"
 description: "What screenwriting can teach us about writing code and prompts. The same craft principles that make stories work — clarity, structure, naming — apply across code, prompts, and communication."
 ---

--- a/_posts/2026/2026-06-25-ethiopia-on-rails-alex-watt.md
+++ b/_posts/2026/2026-06-25-ethiopia-on-rails-alex-watt.md
@@ -10,7 +10,7 @@ author_social:
     url: "https://x.com/alexcwatt"
   - name: "GitHub"
     url: "https://github.com/alexcwatt"
-layout: video
+layout: preview
 author_image: "/images/2026/speakers/alex_watt.jpg"
 description: "Improving healthcare in Addis Ababa, Ethiopia, with a Rails app for mobile medical clinics."
 ---

--- a/_posts/2026/2026-06-25-from-rails-3-to-rails-edge-iliana-hadzhiatanasova.md
+++ b/_posts/2026/2026-06-25-from-rails-3-to-rails-edge-iliana-hadzhiatanasova.md
@@ -6,7 +6,7 @@ author_bio_markdown: "Iliana is a Senior Product Engineer on the Datastores team
 author_social:
   - name: "LinkedIn"
     url: "https://www.linkedin.com/in/ihadzhiatanasova/"
-layout: video
+layout: preview
 author_image: "/images/2026/speakers/iliana_hadzhiatanasova.jpg"
 description: "Intercom has been running on Rails since 2011. Starting from Rails 3.0, today our 3 million line monolith is running on the main branch of Rails. This talk covers our Rails upgrade journey over the last 15 years - the things that broke, the monkey patches keeping it all together, and what it takes to get 300 engineers comfortable shipping on unreleased Rails versions."
 ---

--- a/_posts/2026/2026-06-25-kindness-is-a-superpower-jennie-evans.md
+++ b/_posts/2026/2026-06-25-kindness-is-a-superpower-jennie-evans.md
@@ -6,7 +6,7 @@ author_bio_markdown: "Full stack developer at The Engagement Platform (TEP), who
 author_social:
   - name: "LinkedIn"
     url: "https://www.linkedin.com/in/jennie1evans/"
-layout: video
+layout: preview
 author_image: "/images/2026/speakers/jennie_evans.jpg"
 description: "How kindness shows up in development teams and why it matters. A look at the small acts that make teams stronger."
 ---

--- a/_posts/2026/2026-06-25-performance-engineering-for-everyone-elena-tanasoiu.md
+++ b/_posts/2026/2026-06-25-performance-engineering-for-everyone-elena-tanasoiu.md
@@ -8,7 +8,7 @@ author_social:
     url: "https://elenatanasoiu.com/"
   - name: "GitHub (Emma)"
     url: "https://github.com/emmagabriel"
-layout: video
+layout: preview
 author_image: "/images/2026/speakers/elena_tanasoiu.jpg"
 description: "Your app has a slow endpoint. You've added a database index, turned on caching, reached for larger instances — and you're still guessing. This talk teaches you how to read flamegraphs: the visualization that shows exactly where your code spends time, no guesswork required."
 ---

--- a/_posts/2026/2026-06-25-scaling-sidekiq-managing-multi-tenancy-craig-norford.md
+++ b/_posts/2026/2026-06-25-scaling-sidekiq-managing-multi-tenancy-craig-norford.md
@@ -10,7 +10,7 @@ author_social:
     url: "https://www.linkedin.com/in/craig-norford/"
   - name: "Medium"
     url: "https://medium.com/@craig.a.norford"
-layout: video
+layout: preview
 author_image: "/images/2026/speakers/craig_norford.png"
 description: "Different strategies for managing multi tenancy in Sidekiq and different strategies based on your business needs. Especially looking at balancing cost and compute with shuffle sharding."
 ---

--- a/_posts/2026/2026-06-25-time-is-a-lie-remy-hannequin.md
+++ b/_posts/2026/2026-06-25-time-is-a-lie-remy-hannequin.md
@@ -8,7 +8,7 @@ author_social:
     url: "https://thoughtbot.com"
   - name: "GitHub"
     url: "https://github.com/rhannequin"
-layout: video
+layout: preview
 author_image: "/images/2026/speakers/remy_hannequin.jpg"
 description: "Time seems simple until a background job vanishes during the DST switch or an API silently shifts dates because it assumed UTC. We'll look at why time is genuinely weird, and then work through practical patterns for handling it safely in Ruby and Rails."
 ---

--- a/_posts/2026/2026-06-25-welcome-andy-croll.md
+++ b/_posts/2026/2026-06-25-welcome-andy-croll.md
@@ -5,7 +5,7 @@ author: Andy Croll
 author_social:
   - name: "andycroll.com"
     url: "https://andycroll.com"
-layout: video
+layout: preview
 author_image: "/images/2026/speakers/andy_croll.jpg"
 description: "Welcome to Brighton Ruby 2026."
 ---

--- a/_posts/2026/2026-06-25-woodworking-for-rubyists-tijmen-brommet.md
+++ b/_posts/2026/2026-06-25-woodworking-for-rubyists-tijmen-brommet.md
@@ -6,7 +6,7 @@ author_bio_markdown: "Tijmen Brommet is a developer at CaptionHub, a multimedia 
 author_social:
   - name: "GitHub"
     url: "https://github.com/tijmenb"
-layout: video
+layout: preview
 author_image: "/images/2026/speakers/tijmen_brommet.jpg"
 description: "What woodworking can teach us about software development. From jigs to joints, the parallels between crafting with wood and crafting with code."
 ---

--- a/_posts/2026/2026-06-25-your-experience-is-your-ai-advantage-brian-casel.md
+++ b/_posts/2026/2026-06-25-your-experience-is-your-ai-advantage-brian-casel.md
@@ -8,7 +8,7 @@ author_social:
     url: "https://buildermethods.com"
   - name: "@casjam"
     url: "https://x.com/casjam"
-layout: video
+layout: preview
 author_image: "/images/2026/speakers/brian_casel.jpg"
 description: "Everyone's seen AI spin up a fresh app from scratch. But what about your well-established codebase, with years of decisions, conventions, and real users? Brian Casel argues that experienced developers have the biggest advantage in the AI era, and shows why the best teams are blurring the lines between developer, designer, and product manager—and what that means for us as builders."
 ---

--- a/index.html
+++ b/index.html
@@ -31,6 +31,8 @@ supporters:
 image: 'images/twitter-image.jpg'
 ---
 
+{% include schedule.html %}
+
 {% include twentytwentysix.html %}
 
 {% include gold.html %}


### PR DESCRIPTION
## Summary
- Adds `{% include schedule.html %}` to `index.html` above the `twentytwentysix.html` speaker block, matching how 2024/2025 surfaced the schedule on the home page in the run-up to the conference.
- Flips the eleven 2026 talk posts from `layout: video` to `layout: preview`. They were already set to `video` despite none having a `video_source` yet, which would have hidden them from `schedule.html`'s `preview`/`break` filter. After the conference, flip them back to `video` once recordings land.

## Test plan
- [ ] `bundle exec jekyll serve` and confirm the schedule renders above the speaker grid on `/` with Registration → Welcome → all talks → Coffee/Lunch/Ice Cream/Drinks → Drinks (17:00).
- [ ] Verify break/meal rows render with the muted styling (opacity-50).
- [ ] Confirm individual talk pages still build correctly under the `preview` layout.

## Notes on timings (worth a sanity check before merging)
- Lunch is 2 hours (12:15 → 14:15) vs 75 min in 2025 — assumed intentional Brighton Ruby long lunch.
- Closing slot is 30 min, day ends at 17:00 (vs 17:30 in 2025 with a 60-min Nadia closer). Matches the 2024 pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)