### PR TITLE
ci(videos): Verify videos.brightonruby.com sources in CI

### DIFF
--- a/.github/workflows/check-videos.yml
+++ b/.github/workflows/check-videos.yml
@@ -1,0 +1,23 @@
+name: Check videos
+
+# Catches the failure mode where videos.brightonruby.com stops resolving (e.g.
+# a dropped CNAME) or a talk's video_source path is mistyped — either of which
+# silently breaks the <video> player on talk pages without failing a build.
+on:
+  schedule:
+    - cron: "23 7 * * *" # daily; surfaces silent CDN/DNS regressions
+  pull_request:
+    paths:
+      - "_posts/**"
+      - "bin/check-video-sources"
+      - ".github/workflows/check-videos.yml"
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - name: Verify talk videos are reachable
+        run: ./bin/check-video-sources

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
 
@@ -24,6 +24,9 @@ jobs:
           LANG: C.UTF-8
           LC_ALL: C.UTF-8
         run: bundle exec jekyll build
+
+      - name: Verify talk videos are reachable
+        run: ./bin/check-video-sources
 
       - name: Deploy to Cloudflare
         uses: cloudflare/wrangler-action@v3

--- a/bin/check-video-sources
+++ b/bin/check-video-sources
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# Verify every talk video referenced in _posts is actually reachable.
+#
+# The talk pages embed <source src="//videos.brightonruby.com/..."> pointing at
+# a Bunny CDN pull zone (CNAME: videos.brightonruby.com -> brightonrubyvideo.b-cdn.net,
+# DNS-only). If that CNAME is dropped or a video_source path is mistyped, the
+# <video> player silently breaks on the affected pages with nothing failing the
+# build. This check turns that into a hard, visible failure.
+#
+# Requests are spaced out and any first-pass failure is re-checked after a pause,
+# so transient CDN throttling doesn't produce a false alarm — only a genuine
+# outage (or a real missing file) fails the run.
+#
+# Usage: bin/check-video-sources
+# Exits non-zero if any referenced video is unreachable or not a video.
+
+set -uo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Pull the host/path out of every `video_source: "..."` line in _posts.
+# (Plain read loop rather than mapfile, so this also runs on macOS's bash 3.2.)
+sources=()
+while IFS= read -r line; do
+  sources+=("$line")
+done < <(
+  grep -rhoE 'video_source:[[:space:]]*"[^"]+"' _posts \
+    | sed -E 's/.*"([^"]+)".*/\1/' \
+    | sort -u
+)
+
+if [ "${#sources[@]}" -eq 0 ]; then
+  echo "No video_source entries found in _posts — nothing to check."
+  exit 0
+fi
+
+# HEAD only (no body download). Echoes "CODE|CONTENT_TYPE"; 000 on transport error.
+probe() {
+  curl -sS -o /dev/null -I --max-time 30 \
+    -w '%{http_code}|%{content_type}' "$1" 2>/dev/null || echo '000|'
+}
+
+# A video is healthy when it returns 200/206 with a video/* content type.
+healthy() {
+  case "$1" in 200|206) [[ "$2" == video/* ]] ;; *) false ;; esac
+}
+
+echo "Checking ${#sources[@]} video source(s)…"
+
+# First pass: gentle, spaced out. Collect anything that doesn't look healthy.
+failed=()
+for src in "${sources[@]}"; do
+  res=$(probe "https://${src}")
+  healthy "${res%%|*}" "${res#*|}" || failed+=("$src")
+  sleep 0.2
+done
+
+ok_first=$(( ${#sources[@]} - ${#failed[@]} ))
+echo "First pass: ${ok_first}/${#sources[@]} reachable."
+
+# Confirm pass: real outages stay broken; transient throttling clears after a beat.
+fail=0
+if [ "${#failed[@]}" -gt 0 ]; then
+  echo "Re-checking ${#failed[@]} after a short pause…"
+  sleep 5
+  for src in "${failed[@]}"; do
+    res=$(probe "https://${src}")
+    code=${res%%|*}
+    ctype=${res#*|}
+    if healthy "$code" "$ctype"; then
+      printf '  ok (recovered)  %s\n' "https://${src}"
+    else
+      printf '  FAIL  %-3s  %s  (content-type: %s)\n' "$code" "https://${src}" "${ctype:-none}"
+      fail=1
+    fi
+  done
+fi
+
+echo
+if [ "$fail" -ne 0 ]; then
+  echo "One or more talk videos are unreachable."
+  echo "If ALL failed, the videos.brightonruby.com CNAME is likely missing or"
+  echo "broken — it should point (DNS-only) at brightonrubyvideo.b-cdn.net."
+  exit 1
+fi
+
+echo "All ${#sources[@]} video sources reachable."


### PR DESCRIPTION
## Why

`videos.brightonruby.com` (a Bunny CDN pull zone, reached via a DNS-only CNAME) stopped resolving — the CNAME was dropped during the Cloudflare migration. Talk pages still returned 200, but every `<video>` failed because the host didn't resolve, so all talk videos (2015–2025) broke silently. **Nothing in the build caught it.** The DNS has since been restored; this adds a guard so a recurrence is loud instead of silent.

## What

- **`bin/check-video-sources`** — HEAD-checks every `video_source` in `_posts` (124 of them), asserting `200/206` + a `video/*` content type. Requests are spaced out and any first-pass failure is re-checked after a pause, so Bunny rate-limiting doesn't cause false alarms (a naive burst tripped throttling and produced a spurious failure in testing).
- **`.github/workflows/check-videos.yml`** — runs the check **daily** (the original outage needed no deploy to surface, so a deploy-only gate would've missed it), on **PRs touching `_posts`** (catches mistyped paths in new talks), and on demand.
- **`deploy.yml`** — runs the same check as a pre-deploy gate; job timeout bumped to accommodate it.

## Verification

Ran against production: **124/124 reachable, exit 0, ~3 min.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)