### PR TITLE
Show both headshots for two-speaker talks

### DIFF
--- a/_includes/schedule.html
+++ b/_includes/schedule.html
@@ -38,12 +38,20 @@
           {% endif -%}
           {% if post.author %}
             {% assign image_src = post.author_image | downcase | replace: " ", "_" %}
-            <div class="hidden sm:block w-12 flex-none">
+            <div class="hidden sm:flex sm:gap-1 flex-none">
               <img
                 src="{% include cf_image.html src=image_src width=96 height=96 %}"
-                class="rounded-sm"
+                class="w-12 rounded-sm"
                 alt="{{ post.author }}"
               >
+              {% if post.author_image_2 %}
+                {% assign image_src_2 = post.author_image_2 | downcase | replace: " ", "_" %}
+                <img
+                  src="{% include cf_image.html src=image_src_2 width=96 height=96 %}"
+                  class="w-12 rounded-sm"
+                  alt="{{ post.author }}"
+                >
+              {% endif %}
             </div>
           {% endif %}
           <div class="flex-1">

--- a/_posts/2026/2026-06-25-performance-engineering-for-everyone-elena-tanasoiu.md
+++ b/_posts/2026/2026-06-25-performance-engineering-for-everyone-elena-tanasoiu.md
@@ -10,6 +10,7 @@ author_social:
     url: "https://github.com/emmagabriel"
 layout: preview
 author_image: "/images/2026/speakers/elena_tanasoiu.jpg"
+author_image_2: "/images/2026/speakers/emma_gabriel.jpg"
 description: "Your app has a slow endpoint. You've added a database index, turned on caching, reached for larger instances — and you're still guessing. This talk teaches you how to read flamegraphs: the visualization that shows exactly where your code spends time, no guesswork required."
 ---
 


### PR DESCRIPTION
## What

The homepage schedule grid only rendered a single `author_image`, so the **Performance Engineering for Everyone** talk showed Elena Tanasoiu alone — Emma Gabriel was missing despite co-presenting.

## Changes

- `_includes/schedule.html` — the headshot cell now renders an optional second photo (`author_image_2`) beside the first, as two `w-12` images in a small-gap flex row. Single-speaker talks are unaffected.
- `_posts/2026/...-elena-tanasoiu.md` — added `author_image_2` pointing at `emma_gabriel.jpg` (the headshot was already in `images/2026/speakers/`).

Reusable for any future two-speaker talk — just add `author_image_2` to the post.

## Verification

Production `jekyll build` renders both `elena_tanasoiu.jpg` and `emma_gabriel.jpg` side-by-side on that schedule row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)