### PR TITLE
Fix stretched two-speaker headshots in schedule

### DIFF
--- a/_includes/schedule.html
+++ b/_includes/schedule.html
@@ -38,17 +38,17 @@
           {% endif -%}
           {% if post.author %}
             {% assign image_src = post.author_image | downcase | replace: " ", "_" %}
-            <div class="hidden sm:flex sm:gap-1 flex-none">
+            <div class="hidden sm:flex sm:gap-1 flex-none items-start">
               <img
                 src="{% include cf_image.html src=image_src width=96 height=96 %}"
-                class="w-12 rounded-sm"
+                class="w-12 h-12 object-cover rounded-sm"
                 alt="{{ post.author }}"
               >
               {% if post.author_image_2 %}
                 {% assign image_src_2 = post.author_image_2 | downcase | replace: " ", "_" %}
                 <img
                   src="{% include cf_image.html src=image_src_2 width=96 height=96 %}"
-                  class="w-12 rounded-sm"
+                  class="w-12 h-12 object-cover rounded-sm"
                   alt="{{ post.author }}"
                 >
               {% endif %}


### PR DESCRIPTION
## What

Follow-up to #296. The two-speaker headshots (Elena Tanasoiu & Emma Gabriel) were rendering stretched — narrow and tall — instead of square like every other thumbnail.

## Cause

The flex row I added to hold the second headshot defaults to `align-items: stretch`, so both images were stretched to the row's cross-axis height while keeping their 48px width, distorting them.

## Fix

- Force square thumbnails with fixed `h-12 w-12 object-cover` (matches the 96×96 cover-crop production already serves via Cloudflare).
- Pin `items-start` on the container so flex never stretches them.

Single-speaker rows are unaffected.

## Verification

Built and served locally, screenshotted the homepage: the Elena & Emma headshots now render as two equal squares, matching all other speaker thumbnails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)